### PR TITLE
fix samesite enum bug

### DIFF
--- a/fastapi_sessions/frontends/implementations/cookie.py
+++ b/fastapi_sessions/frontends/implementations/cookie.py
@@ -16,6 +16,9 @@ class SameSiteEnum(str, Enum):
     strict = "strict"
     none = "none"
 
+    def __str__(self):
+        return f"{self.name}"
+
 
 class CookieParameters(BaseModel):
     max_age: int = 14 * 24 * 60 * 60  # 14 days in seconds


### PR DESCRIPTION
- add `__str__` to override the `__str__` of the enum class; fixes #16 
## the issue:
the `sameSiteEnum` is getting serialized wrongly in the set-cookie header. that is because `Enum` class is overriding the `__str__` of the string class. https://github.com/python/cpython/blob/ca3e611b1f620eabb657ef08a95d5f5f554ea773/Lib/enum.py#L1173-L1175

And despite that `response.set_cookie` is doing a great work to check the validity of the cookie parameter but calling the `.lower()` will get the original str but using the variable directly in line#135 is calling the `__str__` method of the enum class hence it bypasses this check.
https://github.com/encode/starlette/blob/master/starlette/responses.py#L129-L136.

## solution:
I added the a `__str__` to get the original string value as described here in the [docs](https://docs.python.org/3/library/enum.html#enum.Enum.__str__).

### before the fix:
![image](https://user-images.githubusercontent.com/61705839/204351180-a9b40d54-7533-49fe-a3b2-904cac9b2a00.png)

### after the fix:
![image](https://user-images.githubusercontent.com/61705839/204351397-65f82dcc-9eb5-4122-a01b-5fffe500f353.png)



Signed-off-by: mahmednabil109 <mahmednabil109@gmail.com>