### PR TITLE
fix: use model_copy instead of copy for pydantic 2 compatibility

### DIFF
--- a/fastapi_sessions/frontends/implementations/cookie.py
+++ b/fastapi_sessions/frontends/implementations/cookie.py
@@ -45,7 +45,7 @@ class SessionCookie(SecurityBase, SessionFrontend[UUID]):
         self.scheme_name = scheme_name or self.__class__.__name__
         self.auto_error = auto_error
         self.signer = URLSafeTimedSerializer(secret_key, salt=cookie_name)
-        self.cookie_params = cookie_params.copy(deep=True)
+        self.cookie_params = cookie_params.model_copy(deep=True)
 
     @property
     def identifier(self) -> str:


### PR DESCRIPTION
In pydantic 2, `copy` of a model is deprecated, we should use `model_copy` instead.

Migration Guide: https://docs.pydantic.dev/2.0/migration/#migration-guide